### PR TITLE
(MODULES-8114) Use old way of defining sensitive params

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -319,8 +319,6 @@ Puppet::Type.newtype(:yumrepo) do
     desc "Password for this proxy. #{ABSENT_DOC}"
 
     newvalues(%r{.*}, :absent)
-
-    sensitive true
   end
 
   newproperty(:s3_enabled) do
@@ -423,6 +421,13 @@ Puppet::Type.newtype(:yumrepo) do
     desc "Password to use with the username for basic authentication.
       #{ABSENT_DOC}"
     newvalues(%r{.*}, :absent)
-    sensitive true
+  end
+
+  private
+
+  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Style/AccessorMethodName
+    parameter(:password).sensitive = true if parameter(:password)
+    parameter(:proxy_password).sensitive = true if parameter(:proxy_password)
+    super(sensitive_parameters)
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.6.0",


### PR DESCRIPTION
The Puppet::Parameter#sensitive DSL method only exists in Puppet 6. We
need to be able to use this module for earlier versions of puppet. This
commit changes how we define sensitive parameters back to the old way.