### PR TITLE
(MODULES-10357) Fix `proxy => absent`

### DIFF
--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -321,7 +321,7 @@ Puppet::Type.newtype(:yumrepo) do
 
     munge do |value|
       return '' if Facter.value(:operatingsystemmajrelease).to_i >= 8 && value.to_s == '_none_'
-      value.to_s
+      super(value)
     end
   end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,12 +4,11 @@ require 'beaker/puppet_install_helper'
 
 $LOAD_PATH << File.join(__dir__, 'acceptance/lib')
 
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
 RSpec.configure do |c|
   c.before :suite do
-    unless ENV['BEAKER_provision'] == 'no'
-      run_puppet_install_helper
-      install_module_on(hosts)
-      install_module_dependencies_on(hosts)
-    end
+    install_module
+    install_module_dependencies
   end
 end


### PR DESCRIPTION
The provider is expecting `absent` to be a symbol.

From https://puppet.com/docs/puppet/latest/custom_types.html

> The default munge method converts any values that are specifically
allowed into symbols. If you override either of these methods, note that
you lose this value handling and symbol conversion, which you’ll have to
call super for.