### PR TITLE
(MODULES-10617) Add property module_hotfixes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -130,6 +130,13 @@ Valid values: YUM_BOOLEAN, absent
 Whether yum will allow the use of package groups for this
 repository.
 
+##### `module_hotfixes`
+
+Valid values: YUM_BOOLEAN, absent
+
+To make the system use packages from a repository regardless of 
+their modularity, specify module_hotfixes=true in the .repo file.
+
 ##### `failovermethod`
 
 Valid values: %r{^roundrobin|priority$}, absent

--- a/lib/puppet/type/yumrepo.rb
+++ b/lib/puppet/type/yumrepo.rb
@@ -204,6 +204,15 @@ Puppet::Type.newtype(:yumrepo) do
     munge(&munge_yum_bool)
   end
 
+  newproperty(:module_hotfixes) do
+    desc "Whether packages from this repo can be installed into modules.
+      #{YUM_BOOLEAN_DOC}
+      #{ABSENT_DOC}"
+
+    newvalues(YUM_BOOLEAN, :absent)
+    munge(&munge_yum_bool)
+  end
+
   newproperty(:failovermethod) do
     desc "The failover method for this repository; should be either
       `roundrobin` or `priority`. #{ABSENT_DOC}"

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -222,6 +222,11 @@ describe Puppet::Type.type(:yumrepo) do
       it_behaves_like 'a yumrepo parameter that can be absent', :enablegroups
     end
 
+    describe 'module_hotfixes' do
+      it_behaves_like 'a yumrepo parameter that expects a boolean parameter', :module_hotfixes
+      it_behaves_like 'a yumrepo parameter that can be absent', :module_hotfixes
+    end
+
     describe 'failovermethod' do
       ['roundrobin', 'priority'].each do |value|
         it "accepts a value of #{value}" do


### PR DESCRIPTION
(MODULES-10617) Add property module_hotfixes..
Per https://dnf.readthedocs.io/en/latest/modularity.html#hotfix-repositories,
if package you have rebuilt and put into your local repository belongs to
a module, it will not be installed even with better version, because
of the filtering by modules.

To make the system use packages from a repository regardless of their
modularity, specify module_hotfixes=true in the .repo file.
This protects the repository from package filtering.