### PR TITLE
(maint) Release prep for 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.7](https://github.com/puppetlabs/puppetlabs-yumrepo_core/tree/1.0.7) (2020-04-13)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-yumrepo_core/compare/1.0.6...1.0.7)
+
+### Added
+
+- \(MODULES-10617\) Add property module\_hotfixes [\#28](https://github.com/puppetlabs/puppetlabs-yumrepo_core/pull/28) ([seriv](https://github.com/seriv))
+
 ## [1.0.6](https://github.com/puppetlabs/puppetlabs-yumrepo_core/tree/1.0.6) (2019-12-19)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-yumrepo_core/compare/1.0.5...1.0.6)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -134,8 +134,7 @@ repository.
 
 Valid values: YUM_BOOLEAN, absent
 
-To make the system use packages from a repository regardless of 
-their modularity, specify module_hotfixes=true in the .repo file.
+Whether packages from this repo can be installed into modules.
 
 ##### `failovermethod`
 
@@ -192,6 +191,15 @@ Priority of this repository. Can be any integer value
 (including negative). Requires that the `priorities` plugin
 is installed and enabled.
 
+##### `minrate`
+
+Valid values: %r{^\d+$}, absent
+
+Sets the low speed threshold in bytes per second.
+If the server is sending data slower than this for at least
+`timeout` seconds, Yum aborts the connection. The default is
+`1000`.
+
 ##### `throttle`
 
 Valid values: %r{^\d+[kMG%]?$}, absent
@@ -222,8 +230,8 @@ Cost of this repository.
 Valid values: %r{.*}, absent
 
 URL of a proxy server that Yum should use when accessing this repository.
-This attribute can also be set to `'_none_'`, which will make Yum bypass any
-global proxy settings when accessing this repository.
+This attribute can also be set to '_none_' (or '' for EL >= 8 only),
+which will make Yum bypass any global proxy settings when accessing this repository.
 
 ##### `proxy_username`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-yumrepo_core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "puppetlabs",
   "summary": "Manage client yum repo configurations by parsing yum INI configuration files.",
   "license": "Apache-2.0",
@@ -16,7 +16,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -32,7 +33,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -48,7 +50,10 @@
       "operatingsystemrelease": [
         "26",
         "27",
-        "28"
+        "28",
+        "29",
+        "30",
+        "31"
       ]
     }
   ],


### PR DESCRIPTION
Run `puppet strings` to update documentation and update the list of supported platforms.

![image](https://user-images.githubusercontent.com/25789827/79111529-58abd500-7d85-11ea-976f-7b08c93bd09f.png)
