### PR TITLE
(maint) Add commits rake task, speed up Windows GitHub Actions and add back missing gems

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6, 7 ]
         include:
           - puppet_version: 5
@@ -28,7 +28,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install ruby version ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1
@@ -27,6 +29,9 @@ jobs:
 
       - name: Prepare testing environment with bundler
         run: bundle update --jobs 4 --retry 3
+
+      - name: Run commits check
+        run: bundle exec rake commits
 
       - name: Run rubocop check
         run: bundle exec rake ${{ env.extra_checks }} rubocop

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6, 7 ]
         include:
           - puppet_version: 5
@@ -30,7 +30,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6 ]
         include:
           - puppet_version: 5
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
           - os: 'macos-10.15'
             os_type: 'macOS'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
 
     runs-on: ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ group :system_tests do
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
+  gem "pdk", '~> 1.18',                                                          platforms: [:ruby]
+  gem "puppet-blacksmith", '~> 3.4',                                             require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -84,3 +84,28 @@ EOM
   end
 end
 
+desc "verify that commit messages match CONTRIBUTING.md requirements"
+task(:commits) do
+  # This rake task looks at the summary from every commit from this branch not
+  # in the branch targeted for a PR.
+  commit_range = 'HEAD^..HEAD'
+  puts "Checking commits #{commit_range}"
+  %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
+    # This regex tests for the currently supported commit summary tokens.
+    # The exception tries to explain it in more full.
+    if /^\((maint|packaging|doc|docs|modules-\d+)\)|revert/i.match(commit_summary).nil?
+      raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
+        "\n\t\t#{commit_summary}\n" \
+        "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \
+        "\t\t(MODULES-<digits>) # this is most common and should be a ticket at tickets.puppet.com\n" \
+        "\t\t(docs)\n" \
+        "\t\t(docs)(DOCUMENT-<digits>)\n" \
+        "\t\t(packaging)\n"
+        "\t\t(maint)\n" \
+        "\n\tThis test for the commit summary is case-insensitive.\n\n\n"
+    else
+      puts "#{commit_summary}"
+    end
+    puts "...passed"
+  end
+end


### PR DESCRIPTION
The `commits` rake task is added in `Rakefile` and now runs in the `Static Code Analysis` workflow as a step.

Unit tests seem to be running much faster on `Windows 2016` with `GitHub Actions` than `Windows 2019`.

During the removal of `puppet-module-dev`, the `pdk` and `puppet-blacksmith` gems were also removed by mistake. This commit makes us able to release again.