### PR TITLE
(MODULES-10945) Core module spring cleaning 2021

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: 2.5
+      ruby_version: 2.6
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
 
     runs-on: 'ubuntu-18.04'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Prepare testing environment with bundler
         run: |
           git config --global core.longpaths true
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run commits check

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -13,10 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -54,6 +54,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
+          - puppet_version: 7
+            ruby: 2.7
 
           - os: 'ubuntu-18.04'
             os_type: 'Linux'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run unit tests

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,11 @@ group :system_tests do
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.0')
-  gem "pdk", '~> 1.18',                                                          platforms: [:ruby]
+end
+
+group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
+  gem "pdk",                                                                     platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -32,16 +32,16 @@ group :development do
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-strings",                                          require: false
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
+
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
-  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~>1.0')
-  gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1.3')
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 0.5',                  require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 0.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.5')
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :system_tests do
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
+  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.0')
   gem "pdk", '~> 1.18',                                                          platforms: [:ruby]
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
 end


### PR DESCRIPTION
Create a separate group in the `Gemfile` for `pdk` and `puppet-blacksmith` which are only used for releasing. In the workflow, avoid installing the release group.

Pin `puppet-module-posix-system` and `puppet-module-win-system` to an older version since the newer ones do not bundle some gems that we use in acceptance (i.e. `beaker-module_install_helper`), causing tests to fail.

Update the workflow that tests with released Puppet gems to also test with Puppet 7.

Bump Ruby version in the static code analysis workflow to 2.6, as 2.5 will be EOL soon.

Remove testing with Puppet 5 from the workflows since it reached EOL.

Add `beaker-puppet` and `puppet-strings` to the Gemfile since other core modules have them.