### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,55 +12,25 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7",
-        "8"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7",
-        "8"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "26",
-        "27",
-        "28",
-        "29",
-        "30",
-        "31"
-      ]
+      "operatingsystem": "Fedora"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/lib/puppet_spec/compiler.rb
+++ b/spec/lib/puppet_spec/compiler.rb
@@ -19,7 +19,7 @@ module PuppetSpec::Compiler
     if Puppet.version.to_f < 5.0
       args << 'apply'
       # rubocop:disable RSpec/AnyInstance
-      Puppet::Transaction::Persistence.any_instance.stubs(:save)
+      allow_any_instance_of(Puppet::Transaction::Persistence).to receive(:save)
       # rubocop:enable RSpec/AnyInstance
     end
     catalog = compile_to_ral(manifest)
@@ -37,7 +37,7 @@ module PuppetSpec::Compiler
 
   def apply_with_error_check(manifest)
     apply_compiled_manifest(manifest) do |res|
-      res.expects(:err).never
+      expect(res).not_to receive(:err)
     end
   end
 end

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -11,7 +11,7 @@ module PuppetSpec::Files
     until @global_tempfiles.empty?
       path = @global_tempfiles.pop
       begin
-        Dir.unstub(:entries)
+        allow(Dir).to receive(:entries).and_call_original
         FileUtils.rm_rf path, secure: true
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/yumrepo/inifile_spec.rb
+++ b/spec/unit/provider/yumrepo/inifile_spec.rb
@@ -12,9 +12,9 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
 
   describe 'enumerating all yum repo files' do
     it 'reads all files in the directories specified by reposdir' do
-      described_class.expects(:reposdir).returns ['/etc/yum.repos.d']
+      expect(described_class).to receive(:reposdir).and_return ['/etc/yum.repos.d']
 
-      Dir.expects(:glob).with('/etc/yum.repos.d/*.repo').returns(['/etc/yum.repos.d/first.repo', '/etc/yum.repos.d/second.repo'])
+      expect(Dir).to receive(:glob).with('/etc/yum.repos.d/*.repo').and_return(['/etc/yum.repos.d/first.repo', '/etc/yum.repos.d/second.repo'])
 
       actual = described_class.repofiles
       expect(actual).to include('/etc/yum.repos.d/first.repo')
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     end
 
     it "includes '/etc/yum.conf' as the first element" do
-      described_class.expects(:reposdir).returns []
+      expect(described_class).to receive(:reposdir).and_return []
 
       actual = described_class.repofiles
       expect(actual[0]).to eq '/etc/yum.conf'
@@ -31,39 +31,39 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
 
   describe 'generating the virtual inifile' do
     let(:files) { ['/etc/yum.repos.d/first.repo', '/etc/yum.repos.d/second.repo', '/etc/yum.conf'] }
-    let(:collection) { mock('virtual inifile') }
+    let(:collection) { instance_double('Puppet::Util::IniConfig::FileCollection') }
 
     before(:each) do
       described_class.clear
-      Puppet::Util::IniConfig::FileCollection.expects(:new).returns collection
+      allow(Puppet::Util::IniConfig::FileCollection).to receive(:new).and_return collection
     end
 
     it 'reads all files in the directories specified by self.repofiles' do
-      described_class.expects(:repofiles).returns(files)
+      expect(described_class).to receive(:repofiles).and_return(files)
 
       files.each do |file|
-        Puppet::FileSystem.stubs(:file?).with(file).returns true
-        collection.expects(:read).with(file)
+        allow(Puppet::FileSystem).to receive(:file?).with(file).and_return true
+        expect(collection).to receive(:read).with(file)
       end
       described_class.virtual_inifile
     end
 
     it 'ignores repofile entries that are not files' do
-      described_class.expects(:repofiles).returns(files)
+      expect(described_class).to receive(:repofiles).and_return(files)
 
-      Puppet::FileSystem.stubs(:file?).with('/etc/yum.repos.d/first.repo').returns true
-      Puppet::FileSystem.stubs(:file?).with('/etc/yum.repos.d/second.repo').returns false
-      Puppet::FileSystem.stubs(:file?).with('/etc/yum.conf').returns true
+      allow(Puppet::FileSystem).to receive(:file?).with('/etc/yum.repos.d/first.repo').and_return true
+      allow(Puppet::FileSystem).to receive(:file?).with('/etc/yum.repos.d/second.repo').and_return false
+      allow(Puppet::FileSystem).to receive(:file?).with('/etc/yum.conf').and_return true
 
-      collection.expects(:read).with('/etc/yum.repos.d/first.repo').once
-      collection.expects(:read).with('/etc/yum.repos.d/second.repo').never
-      collection.expects(:read).with('/etc/yum.conf').once
+      expect(collection).to receive(:read).with('/etc/yum.repos.d/first.repo').once
+      expect(collection).to receive(:read).with('/etc/yum.repos.d/second.repo').never
+      expect(collection).to receive(:read).with('/etc/yum.conf').once
       described_class.virtual_inifile
     end
   end
 
   describe 'creating provider instances' do
-    let(:virtual_inifile) { stub('virtual inifile') }
+    let(:virtual_inifile) { instance_double('Puppet::Util::IniConfig::FileCollection') }
 
     let(:main_section) do
       sect = Puppet::Util::IniConfig::Section.new('main', '/some/imaginary/file')
@@ -82,11 +82,11 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     end
 
     before :each do
-      described_class.stubs(:virtual_inifile).returns(virtual_inifile)
+      allow(described_class).to receive(:virtual_inifile).and_return(virtual_inifile)
     end
 
     it 'ignores the main section' do
-      virtual_inifile.expects(:each_section).multiple_yields(main_section, updates_section)
+      expect(virtual_inifile).to receive(:each_section).and_yield(main_section).and_yield(updates_section)
 
       instances = described_class.instances
       expect(instances.size).to eq(1)
@@ -94,7 +94,7 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     end
 
     it 'creates provider instances for every non-main section that was found' do
-      virtual_inifile.expects(:each_section).multiple_yields(main_section, updates_section)
+      expect(virtual_inifile).to receive(:each_section).and_yield(main_section).and_yield(updates_section)
 
       sect = described_class.instances.first
       expect(sect.name).to eq 'updates'
@@ -104,17 +104,17 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
   end
 
   describe 'retrieving a section from the inifile' do
-    let(:collection) { stub('ini file collection') }
+    let(:collection) { instance_double('Puppet::Util::IniConfig::FileCollection') }
 
-    let(:ini_section) { stub('ini file section') }
+    let(:ini_section) { instance_double('Puppet::Util::IniConfig::Section') }
 
     before(:each) do
-      described_class.stubs(:virtual_inifile).returns(collection)
+      allow(described_class).to receive(:virtual_inifile).and_return(collection)
     end
 
     describe 'and the requested section exists' do
       before(:each) do
-        collection.stubs(:[]).with('updates').returns ini_section
+        allow(collection).to receive(:[]).with('updates').and_return ini_section
       end
 
       it 'returns the existing section' do
@@ -122,24 +122,24 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
       end
 
       it "doesn't create a new section" do
-        collection.expects(:add_section).never
+        expect(collection).to receive(:add_section).never
         described_class.section('updates')
       end
     end
 
     describe "and the requested section doesn't exist" do
       it 'creates a section in the preferred repodir' do
-        described_class.stubs(:reposdir).returns ['/etc/yum.repos.d', '/etc/alternate.repos.d']
-        collection.expects(:[]).with('updates')
-        collection.expects(:add_section).with('updates', '/etc/alternate.repos.d/updates.repo')
+        allow(described_class).to receive(:reposdir).and_return ['/etc/yum.repos.d', '/etc/alternate.repos.d']
+        expect(collection).to receive(:[]).with('updates')
+        expect(collection).to receive(:add_section).with('updates', '/etc/alternate.repos.d/updates.repo')
 
         described_class.section('updates')
       end
 
       it 'creates a section in yum.conf if no repodirs exist' do
-        described_class.stubs(:reposdir).returns []
-        collection.expects(:[]).with('updates')
-        collection.expects(:add_section).with('updates', '/etc/yum.conf')
+        allow(described_class).to receive(:reposdir).and_return []
+        expect(collection).to receive(:[]).with('updates')
+        expect(collection).to receive(:add_section).with('updates', '/etc/yum.conf')
 
         described_class.section('updates')
       end
@@ -164,68 +164,68 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     end
 
     let(:section) do
-      stub('inifile puppetlabs section', name: 'puppetlabs-products')
+      instance_double('Puppet::Util::IniConfig::Section', name: 'puppetlabs-products')
     end
 
     before(:each) do
       type_instance.provider = provider
-      described_class.stubs(:section).with('puppetlabs-products').returns(section)
+      allow(described_class).to receive(:section).with('puppetlabs-products').and_return(section)
     end
 
     describe 'methods used by ensurable' do
       it '#create sets the yumrepo properties on the according section' do
-        section.expects(:[]=).with('baseurl', 'http://yum.puppetlabs.com/el/6/products/$basearch')
-        section.expects(:[]=).with('name', 'Puppet Labs Products El 6 - $basearch')
-        section.expects(:[]=).with('enabled', '1')
-        section.expects(:[]=).with('gpgcheck', '1')
-        section.expects(:[]=).with('gpgkey', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs')
+        expect(section).to receive(:[]=).with('baseurl', 'http://yum.puppetlabs.com/el/6/products/$basearch')
+        expect(section).to receive(:[]=).with('name', 'Puppet Labs Products El 6 - $basearch')
+        expect(section).to receive(:[]=).with('enabled', '1')
+        expect(section).to receive(:[]=).with('gpgcheck', '1')
+        expect(section).to receive(:[]=).with('gpgkey', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs')
 
         provider.create
       end
 
       it '#exists? checks if the repo has been marked as present' do
-        described_class.stubs(:section).returns(stub(:[]= => nil))
+        allow(described_class).to receive(:section).and_return(instance_double('Puppet::Util::IniConfig::Section', :[]= => nil))
         provider.create
         expect(provider).to be_exist
       end
 
       it '#destroy deletes the associated ini file section' do
-        described_class.expects(:section).returns(section)
-        section.expects(:destroy=).with(true)
+        expect(described_class).to receive(:section).and_return(section)
+        expect(section).to receive(:destroy=).with(true)
         provider.destroy
       end
     end
 
     describe 'getting properties' do
       it "maps the 'descr' property to the 'name' INI property" do
-        section.expects(:[]).with('name').returns 'Some rather long description of the repository'
+        expect(section).to receive(:[]).with('name').and_return 'Some rather long description of the repository'
         expect(provider.descr).to eq 'Some rather long description of the repository'
       end
 
       it 'gets the property from the INI section' do
-        section.expects(:[]).with('enabled').returns '1'
+        expect(section).to receive(:[]).with('enabled').and_return '1'
         expect(provider.enabled).to eq '1'
       end
 
       it 'sets the property as :absent if the INI property is nil' do
-        section.expects(:[]).with('exclude').returns nil
+        expect(section).to receive(:[]).with('exclude').and_return nil
         expect(provider.exclude).to eq :absent
       end
     end
 
     describe 'setting properties' do
       it "maps the 'descr' property to the 'name' INI property" do
-        section.expects(:[]=).with('name', 'Some rather long description of the repository')
+        expect(section).to receive(:[]=).with('name', 'Some rather long description of the repository')
         provider.descr = 'Some rather long description of the repository'
       end
 
       it 'sets the property on the INI section' do
-        section.expects(:[]=).with('enabled', '0')
+        expect(section).to receive(:[]=).with('enabled', '0')
         provider.enabled = '0'
       end
 
       it 'sets the section field to nil when the specified value is absent' do
-        section.expects(:[]=).with('exclude', nil)
+        expect(section).to receive(:[]=).with('exclude', nil)
         provider.exclude = :absent
       end
     end
@@ -235,51 +235,50 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     let(:defaults) { ['/etc/yum.repos.d', '/etc/yum/repos.d'] }
 
     before(:each) do
-      Puppet::FileSystem.stubs(:exist?).with('/etc/yum.repos.d').returns(true)
-      Puppet::FileSystem.stubs(:exist?).with('/etc/yum/repos.d').returns(true)
+      allow(Puppet::FileSystem).to receive(:exist?).with('/etc/yum.repos.d').and_return(true)
+      allow(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/repos.d').and_return(true)
     end
 
     it "returns the default directories if yum.conf doesn't contain a `reposdir` entry" do
-      described_class.stubs(:find_conf_value).with('reposdir', '/etc/yum.conf')
+      allow(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf')
       expect(described_class.reposdir('/etc/yum.conf')).to eq(defaults)
     end
 
     it "includes the directory specified by the yum.conf 'reposdir' entry when the directory is present" do
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/extra.repos.d').returns(true)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/extra.repos.d').and_return(true)
 
-      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns '/etc/yum/extra.repos.d'
+      expect(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf').and_return '/etc/yum/extra.repos.d'
       expect(described_class.reposdir('/etc/yum.conf')).to include('/etc/yum/extra.repos.d')
     end
 
     it 'includes the directory if the value is split by whitespace' do
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/extra.repos.d').returns(true)
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/misc.repos.d').returns(true)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/extra.repos.d').and_return(true)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/misc.repos.d').and_return(true)
 
-      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns '/etc/yum/extra.repos.d /etc/yum/misc.repos.d'
+      expect(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf').and_return '/etc/yum/extra.repos.d /etc/yum/misc.repos.d'
       expect(described_class.reposdir('/etc/yum.conf')).to include('/etc/yum/extra.repos.d', '/etc/yum/misc.repos.d')
     end
 
     it 'includes the directory if the value is split by new lines' do
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/extra.repos.d').returns(true)
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/misc.repos.d').returns(true)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/extra.repos.d').and_return(true)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/misc.repos.d').and_return(true)
 
-      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns "/etc/yum/extra.repos.d\n/etc/yum/misc.repos.d"
+      expect(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf').and_return "/etc/yum/extra.repos.d\n/etc/yum/misc.repos.d"
       expect(described_class.reposdir('/etc/yum.conf')).to include('/etc/yum/extra.repos.d', '/etc/yum/misc.repos.d')
     end
 
     it "doesn't include the directory specified by the yum.conf 'reposdir' entry when the directory is absent" do
-      Puppet::FileSystem.expects(:exist?).with('/etc/yum/extra.repos.d').returns(false)
+      expect(Puppet::FileSystem).to receive(:exist?).with('/etc/yum/extra.repos.d').and_return(false)
 
-      described_class.expects(:find_conf_value).with('reposdir', '/etc/yum.conf').returns '/etc/yum/extra.repos.d'
+      expect(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf').and_return '/etc/yum/extra.repos.d'
       expect(described_class.reposdir('/etc/yum.conf')).not_to include('/etc/yum/extra.repos.d')
     end
 
     it 'logs a warning and returns an empty array if none of the specified repo directories exist' do
-      Puppet::FileSystem.unstub(:exist?)
-      Puppet::FileSystem.stubs(:exist?).returns false
+      allow(Puppet::FileSystem).to receive(:exist?).and_return false
 
-      described_class.stubs(:find_conf_value).with('reposdir', '/etc/yum.conf')
-      Puppet.expects(:debug).with('No yum directories were found on the local filesystem')
+      allow(described_class).to receive(:find_conf_value).with('reposdir', '/etc/yum.conf')
+      expect(Puppet).to receive(:debug).with('No yum directories were found on the local filesystem')
       expect(described_class.reposdir('/etc/yum.conf')).to be_empty
     end
   end
@@ -287,40 +286,40 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
   describe 'looking up a conf value' do
     describe "and the file doesn't exist" do
       it 'returns nil' do
-        Puppet::FileSystem.stubs(:exist?).returns false
+        allow(Puppet::FileSystem).to receive(:exist?).and_return false
         expect(described_class.find_conf_value('reposdir')).to be_nil
       end
     end
 
     describe 'and the file exists' do
-      let(:pfile) { stub('yum.conf physical file') }
-      let(:sect) { stub('ini section') }
+      let(:pfile) { instance_double('Puppet::Util::IniConfig::PhysicalFile') }
+      let(:sect) { instance_double('Puppet::Util::IniConfig::Section') }
 
       before(:each) do
-        Puppet::FileSystem.stubs(:exist?).with('/etc/yum.conf').returns true
-        Puppet::Util::IniConfig::PhysicalFile.stubs(:new).with('/etc/yum.conf').returns pfile
-        pfile.expects(:read)
+        allow(Puppet::FileSystem).to receive(:exist?).with('/etc/yum.conf').and_return true
+        allow(Puppet::Util::IniConfig::PhysicalFile).to receive(:new).with('/etc/yum.conf').and_return pfile
+        allow(pfile).to receive(:read)
       end
 
       it 'creates a PhysicalFile to parse the given file' do
-        pfile.expects(:get_section)
+        expect(pfile).to receive(:get_section)
         described_class.find_conf_value('reposdir')
       end
 
       it "returns nil if the file exists but the 'main' section doesn't exist" do
-        pfile.expects(:get_section).with('main')
+        expect(pfile).to receive(:get_section).with('main')
         expect(described_class.find_conf_value('reposdir')).to be_nil
       end
 
       it "returns nil if the file exists but the INI property doesn't exist" do
-        pfile.expects(:get_section).with('main').returns sect
-        sect.expects(:[]).with('reposdir')
+        expect(pfile).to receive(:get_section).with('main').and_return sect
+        expect(sect).to receive(:[]).with('reposdir')
         expect(described_class.find_conf_value('reposdir')).to be_nil
       end
 
       it 'returns the value if the value is defined in the PhysicalFile' do
-        pfile.expects(:get_section).with('main').returns sect
-        sect.expects(:[]).with('reposdir').returns '/etc/alternate.repos.d'
+        expect(pfile).to receive(:get_section).with('main').and_return sect
+        expect(sect).to receive(:[]).with('reposdir').and_return '/etc/alternate.repos.d'
         expect(described_class.find_conf_value('reposdir')).to eq '/etc/alternate.repos.d'
       end
     end
@@ -347,7 +346,7 @@ describe Puppet::Type.type(:yumrepo).provider(:inifile) do
     let(:yumrepo_conf_file) { tmpfile('yumrepo_conf_file', yumrepo_dir) }
 
     before :each do
-      described_class.stubs(:reposdir).returns [yumrepo_dir]
+      allow(described_class).to receive(:reposdir).and_return [yumrepo_dir]
       type_instance.provider = provider
     end
 
@@ -420,8 +419,8 @@ gpgcheck=0
     before :each do
       yumrepo_dir = tmpdir('yumrepo_provider_specs')
       yumrepo_conf_file = tmpfile('yumrepo_conf_file', yumrepo_dir)
-      described_class.stubs(:reposdir).returns [yumrepo_dir]
-      described_class.stubs(:repofiles).returns [yumrepo_conf_file]
+      allow(described_class).to receive(:reposdir).and_return [yumrepo_dir]
+      allow(described_class).to receive(:repofiles).and_return [yumrepo_conf_file]
     end
 
     it 'redacts "password" on update' do

--- a/spec/unit/type/yumrepo_spec.rb
+++ b/spec/unit/type/yumrepo_spec.rb
@@ -326,27 +326,20 @@ describe Puppet::Type.type(:yumrepo) do
         )
       end
 
-      it 'accepts an empty string' do
-        described_class.new(
-          name: 'puppetlabs',
-          proxy: '',
-        )
-      end
-
       it "munges '_none_' to empty string for EL >= 8" do
-        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('8')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
         instance = described_class.new(name: 'puppetlabs', proxy: '_none_')
         expect(instance[:proxy]).to eq ''
       end
 
-      it "does not munges '_none_' to empty string for EL < 8" do
-        Facter.stubs(:value).with(:operatingsystemmajrelease).returns('7')
+      it "does not munge '_none_' to empty string for EL < 8" do
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('7')
         instance = described_class.new(name: 'puppetlabs', proxy: '_none_')
         expect(instance[:proxy]).to eq '_none_'
       end
 
       it 'does not raise any errors' do
-        expect { described_class.new(name: 'puppetlabs', proxy: '') }.not_to raise_error
+        expect { described_class.new(name: 'puppetlabs', proxy: '_none_') }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.

