### PR TITLE
(maint) Pin the async gem

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -20,6 +20,9 @@ Gemfile:
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
       - gem: github_changelog_generator
+      # We can unpin async when we move to Ruby 3
+      - gem: async
+        version: '~> 1'      
       - gem: beaker-module_install_helper
       - gem: beaker-puppet_install_helper
       - gem: nokogiri

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development do
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
   gem "github_changelog_generator",                                              require: false
+  gem "async", '~> 1',                                                           require: false
   gem "beaker-module_install_helper",                                            require: false
   gem "beaker-puppet_install_helper",                                            require: false
   gem "nokogiri",                                                                require: false

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
       "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
+  "pdk-version": "2.3.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#2.2.0",
   "template-ref": "tags/2.2.0-0-g2381db6"
 }


### PR DESCRIPTION
Async 2.0.0 requires Ruby 3 (which is breaking CI), so we're pinning to 1.x.