### PR TITLE
(maint) Flip version detection

### DIFF
--- a/spec/acceptance/tests/yumrepo_spec.rb
+++ b/spec/acceptance/tests/yumrepo_spec.rb
@@ -59,11 +59,11 @@ ABSENT
         # absent removes the entry, leaving an empty file with a known checksum
         assert_equal(res['ensure'], 'file')
 
-        # Puppet 7 uses SHA256 as the default digest algorithm
-        if %r{^7\.}.match?(on(agent, puppet('--version')).stdout)
-          assert_equal(res['content'], '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
-        else
+        # Puppet 7 and up uses SHA256 as the default digest algorithm
+        if %r{^6\.}.match?(on(agent, puppet('--version')).stdout)
           assert_equal(res['content'], '{md5}d41d8cd98f00b204e9800998ecf8427e')
+        else
+          assert_equal(res['content'], '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
         end
       end
     end


### PR DESCRIPTION
The test incorrectly expected md5 checksums with puppet 8. Now we default to sha256, unless testing with 6. Puppet 5 is EOL.