### PR TITLE
(maint) Fix release prep GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,14 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-  
+    inputs:
+      version:
+        description: "Module version to be released. Must be a valid semver string. (1.2.3)"
+        required: true
+
 jobs:
   release: 
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release.yml@main"
+    with:
+      version: "${{ github.event.inputs.version }}"
     secrets: "inherit"


### PR DESCRIPTION
e3d9d89 updated this module to use PDK template 2.7.5. However, this version of the template does not include https://github.com/puppetlabs/pdk-templates/commit/c3f57b75d543ef7c3143a29b8d86cb57e7a67884 which has changes necessary for the release preparation workflow to function, causing it to fail on run.

This commit updates the release prep GitHub workflow to include an input for version, which is a required variable for the reusable GitHub workflow in puppetlabs/cat-github-actions.