### PR TITLE
(maint) Corrects auto release workflow

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -2,8 +2,14 @@ name: "Auto release"
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Module version to be released. Must be a valid semver string. (1.2.3)"
+        required: true
 
 jobs:
   release_prep:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release_prep.yml@main"
+    with:
+      version: "${{ github.event.inputs.version }}"
     secrets: "inherit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,8 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Module version to be released. Must be a valid semver string. (1.2.3)"
-        required: true
 
 jobs:
   release: 
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release.yml@main"
-    with:
-      version: "${{ github.event.inputs.version }}"
     secrets: "inherit"


### PR DESCRIPTION
6766859 incorrectly updated the "release" GitHub workflow instead of the "auto_release" workflow to address a mismatch between PDK template 2.7.5 and the upstream reusable GitHub workflow used for release preparation.

This commit reverts that change from the "release" workflow and adds it to the "auto_release" workflow.