### PR TITLE
fix path in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yumrepo { 'puppetrepo-products':
   gpgkey    => 'http://myownmirror',
   enabled   => '1',
   gpgcheck  => '1',
-  target    => '/etc/yum.repo.d/puppetlabs.repo',
+  target    => '/etc/yum.repos.d/puppetlabs.repo',
 }
 
 ```

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -27,7 +27,7 @@ yumrepo { 'puppetrepo-products':
   gpgkey    => 'http://myownmirror',
   enabled   => '1',
   gpgcheck  => '1',
-  target    => '/etc/yum.repo.d/puppetlabs.repo',
+  target    => '/etc/yum.repos.d/puppetlabs.repo',
 }
 
 ```


### PR DESCRIPTION
add missing `s` in usage/example, actual path for repos is `/etc/yum.repos.d`