### PR TITLE
(PA-5804) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.