### PR TITLE
Fix repo path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yumrepo { 'puppetrepo-products':
   gpgkey    => 'http://myownmirror',
   enabled   => '1',
   gpgcheck  => '1',
-  target    => '/etc/yum.repo.d/puppetlabs.repo',
+  target    => '/etc/yum.repos.d/puppetlabs.repo',
 }
 
 ```


### PR DESCRIPTION
The README.md file shows an incorrect path for where you would typically store the repo files.